### PR TITLE
Changed references to SparseArray.removeAt() to SparseArray.remove() wit...

### DIFF
--- a/salvage/src/main/java/com/jakewharton/salvage/RecycleBin.java
+++ b/salvage/src/main/java/com/jakewharton/salvage/RecycleBin.java
@@ -70,7 +70,9 @@ public class RecycleBin {
       scrapViews[viewType].put(position, scrap);
     }
 
-    scrap.setAccessibilityDelegate(null);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+        scrap.setAccessibilityDelegate(null);
+    }
   }
 
   /** Move all views remaining in activeViews to scrapViews. */
@@ -98,7 +100,9 @@ public class RecycleBin {
         }
         scrapViews.put(i, victim);
 
-        victim.setAccessibilityDelegate(null);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            victim.setAccessibilityDelegate(null);
+        }
       }
     }
 
@@ -119,7 +123,7 @@ public class RecycleBin {
       final int extras = size - maxViews;
       size--;
       for (int j = 0; j < extras; j++) {
-        scrapPile.removeAt(size--);
+        scrapPile.remove(scrapPile.keyAt(size--));
       }
     }
   }
@@ -129,16 +133,16 @@ public class RecycleBin {
     if (size > 0) {
       // See if we still have a view for this position.
       for (int i = 0; i < size; i++) {
-        View view = scrapViews.get(i);
         int fromPosition = scrapViews.keyAt(i);
+        View view = scrapViews.get(fromPosition);
         if (fromPosition == position) {
-          scrapViews.remove(i);
+          scrapViews.remove(fromPosition);
           return view;
         }
       }
       int index = size - 1;
       View r = scrapViews.valueAt(index);
-      scrapViews.removeAt(index);
+      scrapViews.remove(scrapViews.keyAt(index));
       return r;
     } else {
       return null;

--- a/salvage/src/main/java/com/jakewharton/salvage/RecycleBin.java
+++ b/salvage/src/main/java/com/jakewharton/salvage/RecycleBin.java
@@ -71,7 +71,7 @@ public class RecycleBin {
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-        scrap.setAccessibilityDelegate(null);
+      scrap.setAccessibilityDelegate(null);
     }
   }
 
@@ -101,7 +101,7 @@ public class RecycleBin {
         scrapViews.put(i, victim);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-            victim.setAccessibilityDelegate(null);
+          victim.setAccessibilityDelegate(null);
         }
       }
     }


### PR DESCRIPTION
Jake,

Great idea (this project). I made a few beneficial changes that I would like you to accept:

1) I believe there was a small bug in the static retrieveFromScrap function. Within the loop, where you break out early, you were removing from the scrapViews using the for loop's index. I believe you meant to remove by key here.

2) I have changed references to removeAt to remove() with a key look up. This makes the code compatible with versions prior to API level 11.

3) I wrapped the setAccessibilityDelegate in an SDK version check, making it compatible with API levels below 14.

Please accept these changes.

Eric Schlenz

P.S. I am using your ViewPagerIndicator library. Love it! Nice stuff you are contributing.
